### PR TITLE
Fix typo in data set decoding and fix not joined processes in map_in_pool

### DIFF
--- a/src/joinseg.py
+++ b/src/joinseg.py
@@ -592,7 +592,7 @@ def map_in_pool(fn, data, single_process=False, verbose=False):
         print("Caught KeyboardInterrupt, terminating workers")
         pool.terminate()
         raise
-    else:
+    finally:
         pool.close()
         pool.join()
 

--- a/src/pascalseg.py
+++ b/src/pascalseg.py
@@ -180,8 +180,8 @@ def normalize_readable(name, collapse_adjectives):
     # Long names for short part names that are unexplained in the file.
     decoded_names = dict(
             lfho='left front hoof',
-            rfho='right back hoof',
-            lbho='left front hoof',
+            rfho='right front hoof',
+            lbho='left back hoof',
             rbho='right back hoof',
             fwheel='front wheel',
             bwheel='back wheel',

--- a/src/synonym.py
+++ b/src/synonym.py
@@ -115,7 +115,7 @@ common_names = {
 'aeroplane': ['airplane'],
 'airplane': ['airplane', 'aeroplane', 'plane'],
 'spectacles': ['eyeglasses'],
-'windopane': ['window'],  # ade20k calls windows windowpanes.
+'windowpane': ['window'],  # ade20k calls windows windowpanes.
 'dog': ['dog', 'domestic dog', 'canis familiaris'],
 'alga': ['algae'],
 'bicycle': ['bicycle', 'bike', 'cycle'],


### PR DESCRIPTION
There are two typos in pascal data set decoding and a typo in merging synonyms. Also, in map_in_pool, "else" is not reached when there is a return in "try".